### PR TITLE
fix: changed activities order by chronological order

### DIFF
--- a/screens/ActivitiesScreen.tsx
+++ b/screens/ActivitiesScreen.tsx
@@ -109,7 +109,13 @@ export default function ActivitiesScreen() {
                 setLoading(true);
                 const data = await epitechApi.getActivitiesForDate(date);
                 console.log("Activities loaded:", data.length, "events");
-                setActivities(data);
+                // Sort activities chronologically by start time
+                const sorted = [...data].sort(
+                    (a, b) =>
+                        new Date(a.start).getTime() -
+                        new Date(b.start).getTime(),
+                );
+                setActivities(sorted);
             } catch (error: any) {
                 console.error("Load activities error:", error);
                 console.error(


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `ActivitiesScreen`. Activities are now sorted chronologically by their start time before being displayed, ensuring a more intuitive user experience.

* Activities are sorted by their `start` time in ascending order before calling `setActivities`, so users see events in the correct order. (`screens/ActivitiesScreen.tsx`)